### PR TITLE
Feature/load transactions from json file on startup

### DIFF
--- a/src/BudgetBook.Cli/Program.cs
+++ b/src/BudgetBook.Cli/Program.cs
@@ -2,6 +2,7 @@
 using BudgetBook.Persistence;
 
 using var persistence = new PersistenceManager();
+await persistence.LoadTransactionsAsync(DateTime.Now.Year, DateTime.Now.Month);
 
 int choice = 4; // Default choice is 4 (Exit)
 

--- a/src/BudgetBook.Core/TransactionStore.cs
+++ b/src/BudgetBook.Core/TransactionStore.cs
@@ -21,6 +21,11 @@ public sealed class TransactionStore
         TransactionAdded?.Invoke(this, transaction);
     }
 
+    public void AddTransactionSilently(Transaction transaction)
+    {
+        _transactions.Add(transaction);
+    }
+
     public IEnumerable<Transaction> GetTransactions()
     {
         return _transactions;

--- a/src/BudgetBook.Persistence/PersistanceManager.cs
+++ b/src/BudgetBook.Persistence/PersistanceManager.cs
@@ -18,18 +18,25 @@ public class PersistenceManager : IDisposable
     {
         Task task = SaveTransactionAsync(transaction);
 
+        AddRunningTask(task);
+
+        task.ContinueWith(t => RemoveRunningTask(task));
+    }
+
+    private void AddRunningTask(Task task)
+    {
         lock (_lock)
         {
             _runningTasks.Add(task);
         }
+    }
 
-        task.ContinueWith(t =>
+    private void RemoveRunningTask(Task task)
+    {
+        lock (_lock)
         {
-            lock (_lock)
-            {
-                _runningTasks.Remove(task);
-            }
-        });
+            _runningTasks.Remove(task);
+        }
     }
 
     private async Task SaveTransactionAsync(Transaction transaction)

--- a/src/BudgetBook.Persistence/PersistanceManager.cs
+++ b/src/BudgetBook.Persistence/PersistanceManager.cs
@@ -83,7 +83,30 @@ public class PersistenceManager : IDisposable
 
     public async Task LoadTransactionsAsync(int year, int month)
     {
+        try
+        {
+            string basePath = CreateBasePath();
+            Directory.CreateDirectory(basePath);
 
+            string fileName = Path.Combine(basePath, $"{year:D4}-{month:D2}.json");
+
+            List<Transaction> transactions = [];
+            if (File.Exists(fileName))
+            {
+                string json = await File.ReadAllTextAsync(fileName);
+                transactions = JsonSerializer.Deserialize<List<Transaction>>(json) ?? [];
+
+                foreach (Transaction tx in transactions)
+                {
+                    TransactionStore.Instance.AddTransaction(tx);
+                }
+            }
+
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"\n[Loading Error]: {ex.Message}");
+        }
     }
 
     public void Dispose()

--- a/src/BudgetBook.Persistence/PersistanceManager.cs
+++ b/src/BudgetBook.Persistence/PersistanceManager.cs
@@ -39,14 +39,20 @@ public class PersistenceManager : IDisposable
         }
     }
 
+    private string CreateBasePath()
+    {
+        string basePath = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
+                "BudgetBook"
+            );
+        return basePath;
+    }
+
     private async Task SaveTransactionAsync(Transaction transaction)
     {
         try
         {
-            string basePath = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments),
-                "BudgetBook"
-            );
+            string basePath = CreateBasePath();
             Directory.CreateDirectory(basePath);
 
             string fileName = Path.Combine(basePath, $"{transaction.Date:yyyy-MM}.json");

--- a/src/BudgetBook.Persistence/PersistanceManager.cs
+++ b/src/BudgetBook.Persistence/PersistanceManager.cs
@@ -75,6 +75,11 @@ public class PersistenceManager : IDisposable
         }
     }
 
+    public async Task LoadTransactionsAsync(int year, int month)
+    {
+
+    }
+
     public void Dispose()
     {
         TransactionStore.Instance.TransactionAdded -= OnTransactionAdded;

--- a/src/BudgetBook.Persistence/PersistanceManager.cs
+++ b/src/BudgetBook.Persistence/PersistanceManager.cs
@@ -98,7 +98,7 @@ public class PersistenceManager : IDisposable
 
                 foreach (Transaction tx in transactions)
                 {
-                    TransactionStore.Instance.AddTransaction(tx);
+                    TransactionStore.Instance.AddTransactionSilently(tx);
                 }
             }
 


### PR DESCRIPTION
## Summary
Implements the "load on startup" feature to ensure that all transactions of the current month are available in memory when the application starts.

## Changes
- Added `AddTransactionSilently` to prevent re-saving transactions back to the JSON file during initialization.
- On startup, all transactions of the current month are automatically loaded into the `TransactionStore`.

## Testing
1. Add an expense or income transaction and restart the software. 
→Expected: When navigating to "Today's Report", the recently added transaction is visible.  
2. Start the software and navigate to "Monthly Report".
→Expected: All transactions of the current month are displayed immediately.

## Related Issue
Closes #12 