### PR TITLE
Implement a asynchronouse flush method in PersistenceManager to have …

### DIFF
--- a/src/BudgetBook.Cli/Program.cs
+++ b/src/BudgetBook.Cli/Program.cs
@@ -1,7 +1,7 @@
 ﻿using BudgetBook.Core;
 using BudgetBook.Persistence;
 
-using var persistence = new PersistenceManager();
+await using var persistence = new PersistenceManager();
 await persistence.LoadTransactionsAsync(DateTime.Now.Year, DateTime.Now.Month);
 
 int choice = 4; // Default choice is 4 (Exit)

--- a/src/BudgetBook.Persistence/PersistanceManager.cs
+++ b/src/BudgetBook.Persistence/PersistanceManager.cs
@@ -5,7 +5,7 @@ using System.Text.Json;
 
 namespace BudgetBook.Persistence;
 
-public class PersistenceManager : IDisposable
+public class PersistenceManager : IDisposable, IAsyncDisposable
 {
     public PersistenceManager()
     {
@@ -109,8 +109,29 @@ public class PersistenceManager : IDisposable
         }
     }
 
+    /// <summary>
+    /// Is waiting for all running write processes.
+    /// Should be called on App-Shutdown.
+    /// </summary>
+    public async Task FlushAsync()
+    {
+        Task[] tasksCopy;
+        lock (_lock)
+        {
+            tasksCopy = _runningTasks.ToArray();
+        }
+        await Task.WhenAll(tasksCopy);
+    }
+
     public void Dispose()
     {
         TransactionStore.Instance.TransactionAdded -= OnTransactionAdded;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await FlushAsync();
+
+        Dispose();
     }
 }


### PR DESCRIPTION
## Summary
Implements a asynchronouse flush method to garanty the software whaits until all tasks are done before terminating, to avoid data loss.

## Changes
- Implement an asynchronous flush method and call it in a asynchronouse Dispose method, so it starts automatically by shutdown.
- innitialize the persistence manager object with await

## Testing
1. Add an income/expense and shutdown simultaniously the software with `ctrl+d`
→Expected: Before terminating and turning back to the terminal the writign proces is finished.  

## Related Issue
Closes #13 